### PR TITLE
Update for go 1.13 and beyond.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: go
 go:
-  - 1.3
-  - 1.4
-  - tip
+  - 1.13
+  - stable

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/rdegges/go-ipify
+
+go 1.13
+
+require github.com/jpillora/backoff v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/ipify_test.go
+++ b/ipify_test.go
@@ -1,22 +1,26 @@
 package ipify
 
 import (
+	"fmt"
 	"testing"
 )
 
 func TestGetIp(t *testing.T) {
 	originalApiUri := API_URI
 
-	_, err := GetIp()
+	ip, err := GetIp()
 	if err != nil {
 		t.Error(err)
 	}
+	fmt.Println(ip)
 
 	API_URI = "https://api.ipifyyyyyyyyyyyy.org"
 
-	_, err = GetIp()
-	if err == nil {
+	ip, err = GetIp()
+	if err == nil || ip != "" {
 		t.Error("Request to https://api.ipifyyyyyyyyyyyy.org should have failed, but succeeded.")
+	} else {
+		fmt.Println(err)
 	}
 
 	API_URI = originalApiUri

--- a/settings.go
+++ b/settings.go
@@ -7,7 +7,7 @@ import (
 )
 
 // The version of this library.
-const VERSION = "1.0.0"
+const VERSION = "1.0.1"
 
 // The maximum amount of tries to attempt when making API calls.
 const MAX_TRIES = 3


### PR DESCRIPTION
Implements #2 and adds module support.
Changes the minimum go version to 1.13, which is the minimum go version for the backoff dependency.
#2 can be closed if this PR is merged.